### PR TITLE
fix: faq-problem.html resolve duplicate anchor

### DIFF
--- a/en/faqs/faq-problem.html
+++ b/en/faqs/faq-problem.html
@@ -30,7 +30,7 @@
 <LI><A HREF="#t">Why isn't there a green light for the On/Off radio button on the main screen ?</A>
 <LI><A HREF="#u">Why does the action Display Brightness cause my keyboard or application to close ?</A>
 <LI><A HREF="#v">Why is the date in Tasker's notification list completely wrong ?</A>
-<LI><A HREF="#w">Why won't Tasker install on my custom ROM ?</A>
+<LI><A HREF="#rom">Why won't Tasker install on my custom ROM ?</A>
 <LI><A HREF="#x">Why doesn't my <CODE>Perform Task</CODE> action work when I Test it ?</A>
 <LI><A HREF="#app">Why doesn't my App Context work ?</A>
 <LI><A HREF="#keyguard">Why doesn't the Keyguard action work properly ?</A>
@@ -435,7 +435,7 @@ Changing to a non-transparent icon or a custom layout will fix the problem.
 </P>
 
 <!----------------------------------------------------------------------------->
-<A NAME="w"/>
+<A NAME="rom"/>
 <H4>Why won't Tasker install on my custom ROM ?</H4>
 
 The most likely reason is that you don't have Google Maps installed on the device. With


### PR DESCRIPTION
I don't know which is more often externally referenced, ROM or settings restored, but since #w currently points to settings restored, I'm thinking that's the one to keep.